### PR TITLE
New features, changes and bugfixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,6 @@ jobs:
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ env.TAG_NAME }}
           files: "${{ env.REPO_NAME }}-${{ env.TAG_NAME }}.zip"

--- a/Blunder.xml
+++ b/Blunder.xml
@@ -7113,7 +7113,8 @@ end</script>
 						</Trigger>
 						<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 							<name>Path Distance</name>
-							<script>snd.pathfind_distance = tonumber(matches[2])</script>
+						<script>snd.pathfind_distance = tonumber(matches[2])
+snd.pathfind_remain_trig = false</script>
 							<triggerType>0</triggerType>
 							<conditonLineDelta>0</conditonLineDelta>
 							<mStayOpen>0</mStayOpen>
@@ -7133,7 +7134,8 @@ end</script>
 						</Trigger>
 						<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 							<name>Path Left To Travel</name>
-							<script>snd.pathfind_remain = tonumber(matches[2])</script>
+						<script>snd.pathfind_remain = tonumber(matches[2])
+snd.pathfind_remain_trig = true</script>
 							<triggerType>0</triggerType>
 							<conditonLineDelta>0</conditonLineDelta>
 							<mStayOpen>0</mStayOpen>
@@ -7151,13 +7153,18 @@ end</script>
 								<integer>1</integer>
 							</regexCodePropertyList>
 						</Trigger>
-						<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+					<Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 							<name>Blockades</name>
 							<script>if gmcp.Char.Vitals.mounted~="0" then
   snd.dismount()
 end
 
-local nextdir = snd.pathfind_distance - snd.pathfind_remain + 1
+local nextdir
+if snd.pathfind_remain_trig then
+  nextdir = snd.pathfind_distance - snd.pathfind_remain + 1
+else
+  nextdir = 1
+end
 local direction = snd.pathfind_path[nextdir]
 local skillnotfound = false
 local advance = false
@@ -7169,17 +7176,18 @@ elseif hasSkill("Tumbling") then
 elseif hasSkill("Advance") then
   advance = true
   send("qb gravitation advance 4 " .. direction)
-  tempTimer(4.1, [[send("path track city")]])
+  tempTimer(4.1, [[send("path track "..snd.pathfind_destination)]])
 else
   skillnotfound = true
 end
 
 if not skillnotfound and not advance then
-  tempTimer(2.7, [[send("path track city")]])
+  tempTimer(2.7, [[send("path track "..snd.pathfind_destination)]])
 end
 if snd.toggles.automount then
   snd.mount()
 end
+snd.pathfind_remain_trig = false
 disableTrigger("Blockades")</script>
 							<triggerType>0</triggerType>
 							<conditonLineDelta>0</conditonLineDelta>
@@ -8633,6 +8641,30 @@ end</script>
 							<string>^(\w+ .+) uses (Animation|Synthesis) (\w+)(?: \((.+)\))? on (\w+)\.$</string>
 						</regexCodeList>
 						<regexCodePropertyList>
+							<integer>1</integer>
+						</regexCodePropertyList>
+					</Trigger>
+					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+						<name>Blood Pillar</name>
+						<script>snd.pillarused = false</script>
+						<triggerType>0</triggerType>
+						<conditonLineDelta>0</conditonLineDelta>
+						<mStayOpen>0</mStayOpen>
+						<mCommand></mCommand>
+						<packageName></packageName>
+						<mFgColor>#ff0000</mFgColor>
+						<mBgColor>#ffff00</mBgColor>
+						<mSoundFile></mSoundFile>
+						<colorTriggerFgColor>#000000</colorTriggerFgColor>
+						<colorTriggerBgColor>#000000</colorTriggerBgColor>
+						<regexCodeList>
+							<string>The pillar tilts to one side and collapses, its magic finally running dry.</string>
+							<string>You have destroyed a blood-webbed pillar.</string>
+							<string>^\w+ has destroyed a blood-webbed pillar\.$</string>
+						</regexCodeList>
+						<regexCodePropertyList>
+							<integer>3</integer>
+							<integer>3</integer>
 							<integer>1</integer>
 						</regexCodePropertyList>
 					</Trigger>
@@ -33119,30 +33151,6 @@ end</script>
 						</regexCodePropertyList>
 					</Trigger>
 				</TriggerGroup>
-				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
-					<name>Blood Pillar</name>
-					<script>snd.pillarused = false</script>
-					<triggerType>0</triggerType>
-					<conditonLineDelta>0</conditonLineDelta>
-					<mStayOpen>0</mStayOpen>
-					<mCommand></mCommand>
-					<packageName></packageName>
-					<mFgColor>#ff0000</mFgColor>
-					<mBgColor>#ffff00</mBgColor>
-					<mSoundFile></mSoundFile>
-					<colorTriggerFgColor>#000000</colorTriggerFgColor>
-					<colorTriggerBgColor>#000000</colorTriggerBgColor>
-					<regexCodeList>
-						<string>The pillar tilts to one side and collapses, its magic finally running dry.</string>
-						<string>You have destroyed a blood-webbed pillar.</string>
-						<string>^\w+ has destroyed a blood-webbed pillar\.$</string>
-					</regexCodeList>
-					<regexCodePropertyList>
-						<integer>3</integer>
-						<integer>3</integer>
-						<integer>1</integer>
-					</regexCodePropertyList>
-				</Trigger>
 			</TriggerGroup>
 			<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>Ylem</name>
@@ -34777,7 +34785,7 @@ end</script>
 					<regexCodePropertyList />
 					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 						<name>Get that key</name>
-						<script>if snd.toggles.questing then
+						<script>if snd.toggles.questing and snd.my.area == "the Arurer Haven" then
 	send("qeb take 158672")
 	havekey = true
 	tempTimer(600, [[havekey = false]])
@@ -34801,7 +34809,7 @@ end</script>
 					</Trigger>
 					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 						<name>Unlock chest</name>
-						<script>if snd.toggles.questing then
+						<script>if snd.toggles.questing and snd.my.area == "the Arurer Haven" then
 	if havekey then
 		send("qeb unlock chest"..snd.sep.."open chest"..snd.sep.."take seashell from chest"..snd.sep.."give seashell to gunder")
 		havekey = false
@@ -38444,16 +38452,30 @@ cecho("&lt;red&gt;Will use &lt;orange&gt;"..(snd.toggles.laesan and "Laesan" or 
 					</Alias>
 					<Alias isActive="yes" isFolder="no">
 						<name>Prism Defense</name>
-						<script>if matches[2] == "off" then
+						<script>if isActive("Prism Defense", "trigger") &gt; 0 then
   disableTrigger("Prism Defense")
-  cecho("&lt;yellow&gt;Prism Defense DISABLED.")
+  snd.message(string.title("Prism Defense") .. " &lt;red&gt;OFF&lt;white&gt;!", "toggle")
  else
   enableTrigger("Prism Defense")
-  cecho("&lt;yellow&gt;Prism Defense ENABLED.")
+  snd.message(string.title("Prism Defense") .. " &lt;green&gt;ON&lt;white&gt;!", "toggle")
 end</script>
 						<command></command>
 						<packageName></packageName>
-						<regex>^prismdef\s?(\w+)?$</regex>
+						<regex>^toggle prismdef$</regex>
+					</Alias>
+					<Alias isActive="yes" isFolder="no">
+						<name>Stability Artifact</name>
+						<script>snd.toggle("stability")</script>
+						<command></command>
+						<packageName></packageName>
+						<regex>^toggle stability$</regex>
+					</Alias>
+					<Alias isActive="yes" isFolder="no">
+						<name>Chat Timestamps</name>
+						<script>snd.toggle("chattime")</script>
+						<command></command>
+						<packageName></packageName>
+						<regex>^toggle chattime$</regex>
 					</Alias>
 				</AliasGroup>
 				<AliasGroup isActive="yes" isFolder="yes">
@@ -38514,7 +38536,9 @@ end</script>
 else
  snd.send("qeb "..matches[2])
 end
-</script>
+if not snd.toggles.bashing then
+  raiseEvent("sunder_update_toggles")
+end</script>
 						<command></command>
 						<packageName></packageName>
 						<regex>^(n|e|s|w|ne|nw|se|sw|in|up?|out|o|d|down)$</regex>
@@ -38571,8 +38595,9 @@ local temp, maptable = yajl.to_value(tmp), {}
 for k, v in pairs(temp) do
   maptable[k:lower()] = v
 end
-local destinationRoom = maptable[matches[2]:lower()]
+destinationRoom = maptable[matches[2]:lower()]
 snd.moving_to = (destinationRoom or snd.landmarks[matches[2]:lower()] or matches[2])
+snd.pathfind_destination = snd.moving_to
 
 snd.core()</script>
 						<command></command>
@@ -38873,7 +38898,8 @@ send(" ")</script>
 				</Alias>
 				<Alias isActive="yes" isFolder="no">
 					<name>defense options</name>
-					<script>local selection = ""
+					<script>class_catch()
+local selection = ""
 if matches[3] then 
   selection = matches[3] 
 else
@@ -58878,7 +58904,6 @@ registerAnonymousEventHandler("gmcp.Char.Name", "snd.login")</script>
 					<script>function snd.deathCheck()
   if gmcp.Char.Afflictions.Add.name == "dead" then
     snd.stap()
-    snd.reset_me()
     snd.target_gone = true
     snd.toggles.active = false
     raiseEvent("sunder_update_toggles")
@@ -58898,6 +58923,8 @@ function snd.deathClear()
         snd.defenses[i].needit = false
       end
       snd.toggles.active = true
+      raiseEvent("sunder_enemy_affs_updated")
+      raiseEvent("sunder_enemy_limbs_updated")
       raiseEvent("sunder_update_toggles")
     end
   end
@@ -59049,6 +59076,7 @@ vermin = false, -- Toggle vermin walker/basher
 goggles = false, -- Do you have the antiquated artifact goggles?
 goggle_level = 0,
 gauntlet_level = 0,
+stability = false, -- Do you have the stability artifact?
 diagaffs = 3,
 nontargetgags = true, -- spam filter for removing non-target curing
 fitness = true, -- have access to the fitness ability
@@ -59065,11 +59093,12 @@ gags = true,
 targetrune = false,
 alerts = false,
 followbash = false,
-laesan = true, --try to use laesan while predator bashing. If false, will go for Ein-fasit instead.
+laesan = true, -- try to use laesan while predator bashing. If false, will go for Ein-fasit instead.
 ascendedtype = "none",
 mount = "123456",
 automount = false,
-highlights = true, --npb highlights
+highlights = true, -- npb highlights
+chattime = false -- chat timestamps
 }</script>
 						<eventHandlerList />
 					</Script>
@@ -59274,6 +59303,14 @@ area = "",
 room = "",
 room_name = "",
 room_exits = "",
+}
+
+snd.time = snd.time or {
+t = "",
+d = "",
+m = "",
+y = "",
+night = "",
 }
 
 snd.new = snd.new or {
@@ -59546,6 +59583,28 @@ snd.weapon_types = {
 "kite",
 "tower",
 "shield",
+}
+
+snd.weapon_two_handed = {
+-- Large Blades
+"bardiche",
+"bastard",
+"estoc",
+"falx",
+"glaive",
+"greatspear",
+"halberd",
+"scythe",
+"lance",
+"manta",
+-- Large Bludgeons
+"cudgel",
+"greatmaul",
+"quarterstaff",
+"warhammer",
+"wargauntlets",
+-- Large Thrown
+"javelin",
 }</script>
 						<eventHandlerList />
 					</Script>
@@ -59694,11 +59753,17 @@ end</script>
   if snd.class == "Akkari" then
     snd.defenses.def_stalking = snd.alternative_class_defenses.Akkari_stalking
     snd.defenses.def_hiding = snd.alternative_class_defenses.Akkari_hiding
+    if gmcp.Char.Status.spec ~= "Dosan" then
+      snd.defenses.def_transcendence.needit = false
+    end
   end
   
   if snd.class == "Praenomen" then
     snd.defenses.def_stalking = snd.alternative_class_defenses.Praenomen_stalking
     snd.defenses.def_hiding = snd.alternative_class_defenses.Praenomen_hiding
+    if gmcp.Char.Status.spec ~= "Phreneses" then
+      snd.defenses.def_bloodrage.needit = false
+    end
   end
   if snd.class == "Shapeshifter" then
     snd.defenses.def_celerity = snd.alternative_class_defenses.Shapeshifter_celerity
@@ -59707,6 +59772,18 @@ end</script>
   end
   if hasSkill("Insomnia") then
     snd.defenses.def_insomnia = snd.alternative_class_defenses.Skill_insomnia
+  end
+  if hasSkill("Deathsight") then
+    snd.defenses.def_deathsight = snd.alternative_class_defenses.Skill_deathsight
+  end
+  if hasSkill("Thirdeye") then
+    snd.defenses.def_thirdeye = snd.alternative_class_defenses.Skill_thirdeye
+  end
+  if snd.toggles["stability"] then
+    snd.defenses.def_density = snd.alternative_class_defenses.Artifact_stability
+    if not snd.def_have("def_density") and snd.defenses.def_density.needit == false then
+      snd.defenses.def_density.needit = true
+    end
   end
 
   
@@ -59722,6 +59799,85 @@ end</script>
 end</script>
 						<eventHandlerList>
 							<string>gmcp.Char.Vitals</string>
+						</eventHandlerList>
+					</Script>
+					<Script isActive="yes" isFolder="no">
+						<name>time_update</name>
+						<packageName></packageName>
+						<script>registerAnonymousEventHandler("sunder_login","time_update")
+function time_update()
+  sendGMCP("IRE.Time.Request")
+    
+  snd.time.d = gmcp.IRE.Time.List.day
+  snd.time.m = gmcp.IRE.Time.List.month
+  snd.time.y = gmcp.IRE.Time.List.year
+    
+  snd.time.t = gmcp.IRE.Time.List.time
+  if snd.time.t:find("Twilight has overtaken the light") then
+    	snd.time.t = "Early evening"
+    snd.time.night = true
+  	elseif snd.time.t:find("late night, approaching midnight") then
+    snd.time.t = "Late night"
+    snd.time.night = true
+  elseif snd.time.t:find("It is deep night in Aetolia") then
+    	snd.time.t = "Almost midnight"
+    snd.time.night = true
+  	elseif snd.time.t:find("It is deepest midnight.") then
+    	snd.time.t = "Midnight"
+    snd.time.night = true
+  elseif snd.time.t:find("It is the middle of the night in Aetolia") then
+    	snd.time.t = "After midnight"
+    snd.time.night = true
+  elseif snd.time.t:find("early morning in Aetolia") then
+    	snd.time.t = "Early morning"
+    snd.time.night = true
+  elseif snd.time.t:find("approaching dawn.") then
+    	snd.time.t = "Almost dawn"
+    snd.time.night = true
+  	elseif snd.time.t:find("It is dawn.") then
+    	snd.time.t = "Dawn"
+    snd.time.night = false
+  	elseif snd.time.t:find("It's mid-") then
+    	snd.time.t = "Mid-morning"
+    snd.time.night = false
+  elseif snd.time.t:find("approaching noon") then
+    	snd.time.t = "Almost noon"
+    snd.time.night = false
+  elseif snd.time.t:find("exactly noon") then
+    	snd.time.t = "Hiiiigh noooon"
+    snd.time.night = false
+  	elseif snd.time.t:find("early afternoon") then
+    	snd.time.t = "Early afternoon"
+    snd.time.night = false
+  elseif snd.time.t:find("It is late afternoon in Aetolia") then
+    	snd.time.t = "Late afternoon"
+    snd.time.night = false
+  elseif snd.time.t:find("dusk in Aet") then
+    	snd.time.t = "Dusk"
+    snd.time.night = false
+  else 
+    	--This should only come about if they add a new time to the cycle.
+  	end
+    
+  -- Stuff that should happen on time update
+  if snd.class == "Praenomen" then
+    if snd.time.night then
+      if not snd.def_have("def_stalking") and not snd.defenses["def_stalking"].needit then
+        snd.defenses["def_stalking"].needit = true
+        send(" ")
+      end
+    else
+      snd.defenses["def_stalking"].needit = false
+    end
+  end
+  
+  if snd.gui.enabled then
+    gui_time_update()
+    raiseEvent("sunder_update_vitals")
+  end   
+end</script>
+						<eventHandlerList>
+							<string>gmcp.IRE.Time.Update</string>
 						</eventHandlerList>
 					</Script>
 				</ScriptGroup>
@@ -60212,7 +60368,7 @@ function snd.message(string, type)
     else
       line = "\n"
     end
-    cecho(line.."&lt;green&gt;[&lt;white&gt;SND&lt;green&gt;]&lt;"..color.."&gt; "..string)
+    cecho(line.."&lt;SlateBlue&gt;[&lt;firebrick&gt;Blunder&lt;SlateBlue&gt;]&lt;"..color.."&gt; "..string)
     if type == "reset" then
       send(" ")
     end
@@ -60576,7 +60732,7 @@ end
         cecho("&lt;yellow&gt;Taking detour.")
       end
     end
-    if snd.moving_to == "city" then
+    if snd.moving_to ~= "none" then
       enableTrigger("Blockades")
     end
     if snd.toggles.gallop then
@@ -60744,6 +60900,15 @@ function snd.weaponType(weapon)
     end
   end
   return weapon
+end
+
+function snd.weaponTwohanded(weapon)
+  for wtype in pairs(snd.weapon_two_handed) do
+    if string.find(weapon, snd.weapon_two_handed[wtype]) then
+      return true
+    end
+  end
+  return false
 end
 
 function snd.skillrankcheck(rank)
@@ -62973,9 +63138,9 @@ def_deafness = {defense = "deafness", type = "normal", effect = "Protects from s
 def_blindness = {defense = "blindness", type = "normal", effect = "Protects from visual effects", balance = {herb = "amaurosis"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
 def_waterbreathing = {defense = "waterbreathing", type = "normal", effect = "Prevents choking underwater", balance = {herb = "waterbreathing"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
 def_kola = {defense = "instawake", type = "normal", effect = "Removes the WAKE delay", balance = {herb = "stimulant"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
-def_insomnia = {defense = "insomnia", type = "normal", effect = "Prevents sleep effects", balance = {special = "insomnia"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
-def_deathsight = {defense = "deathsight", type = "normal", effect = "Reports player deaths", balance = {special = "deathsight"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
-def_thirdeye = {defense = "thirdeye", type = "normal", effect = "Adds locations to WHO", balance = {special = "thirdeye"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
+def_insomnia = {defense = "insomnia", type = "normal", effect = "Prevents sleep effects", balance = {eat = "kawhepill"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
+def_deathsight = {defense = "deathsight", type = "normal", effect = "Reports player deaths", balance = {eat = "thanatonin"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
+def_thirdeye = {defense = "thirdeye", type = "normal", effect = "Adds locations to WHO", balance = {eat = "acuity"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
 def_venom = {defense = "antivenin", type = "normal", effect = "Protects against poison damage", balance = {vial = "antivenin"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
 def_levitation = {defense = "levitation", type = "normal", effect = "Protects against falling effects", balance = {vial = "levitation"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
 def_frost = {defense = "temperance", type = "normal", effect = "Protects against fire damage", balance = {vial = "frost"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
@@ -63610,22 +63775,21 @@ Ascendril_empowered_moon = {defense = "empowered_moon", type = "normal", effect 
 Bloodborn_empowered_moon = {defense = "empowered_moon", type = "normal", effect = "extra mana recovery", balance = {balanceequilibriumtake = "unleash acumen"}, state = "down", needit = false, timer = createStopWatch(), skill = "Acumen" },
 Sciomancer_empowered_moon = {defense = "empowered_moon", type = "normal", effect = "extra mana recovery", balance = {balanceequilibriumtake = "cast sagacity"}, state = "down", needit = false, timer = createStopWatch(), skill = "Sagacity" },
 Runecarver_empowered_moon = {defense = "empowered_moon", type = "normal", effect = "extra mana recovery", balance = {balanceequilibriumtake = "runecarve mysticism"}, state = "down", needit = false, timer = createStopWatch(), skill = "Mysticism" },
-Skill_insomnia = {defense = "insomnia", type = "normal", effect = "Prevents sleep effects", balance = {special = "insomnia"}, state = "down", needit = false, timer = createStopWatch(), skill = "Insomnia"},
 Earthcaller_insulation = {defense = "insulation", type = "normal", effect = "Prevents frozen buildup", balance = {balanceequilibriumtake = "tectonic insulation"}, state = "down", needit = false, timer = createStopWatch(), skill = "Insulation"},
 Luminary_insulation = {defense = "insulation", type = "normal", effect = "Prevents frozen buildup", balance = {balanceequilibriumtake = "evoke warmth"}, state = "down", needit = false, timer = createStopWatch(), skill = "Warmth"},
 Ascendril_empowered_boar = {defense = "empowered_boar", type = "DarkOrange", effect = "extra health recovery", balance = {balanceequilibriumtake = "cast vivacity"}, state = "down", needit = false, timer = createStopWatch(), skill = "Vivacity" },
 Bloodborn_empowered_boar = {defense = "empowered_boar", type = "indian_red", effect = "extra health recovery", balance = {balanceequilibriumtake = "unleash acumen"}, state = "down", needit = false, timer = createStopWatch(), skill = "Acumen" },
-}
-
-
-
-</script>
+Skill_insomnia = {defense = "insomnia", type = "normal", effect = "Prevents sleep effects", balance = {special = "insomnia"}, state = "down", needit = false, timer = createStopWatch(), skill = "Insomnia"},
+Skill_deathsight = {defense = "deathsight", type = "normal", effect = "Reports player deaths", balance = {special = "deathsight"}, state = "down", needit = false, timer = createStopWatch(), skill = "Deathsight"},
+Skill_thirdeye = {defense = "thirdeye", type = "normal", effect = "Adds locations to WHO", balance = {special = "thirdeye"}, state = "down", needit = false, timer = createStopWatch(), skill = "Thirdeye"},
+Artifact_stability = {defense = "density", type = "red", effect = "Resists forced movement", balance = {special = "stability"}, state = "down", needit = false, timer = createStopWatch(), skill = "Generic"},
+}</script>
 							<eventHandlerList />
 						</Script>
 						<Script isActive="yes" isFolder="no">
 							<name>give/take defenses</name>
 							<packageName></packageName>
-							<script>local formDefs = {
+							<script>  local formDefs = {
 	def_adherent_form = true,
 	def_seraph_form = true,
 	def_aetherial_form = true,
@@ -63743,6 +63907,7 @@ end</script>
   ["Your mind has been touched by the essence of the Underking."] = "deathsight",
   ["You have insomnia, and cannot easily go to sleep."] = "insomnia",
   ["You possess the sight of the third eye."] = "thirdeye",
+  ["A seen sense that allows you to pierce through the shroud and see the location of individuals."] = "thirdeye",
   ["Your resistance to damage by poison has been increased."] = "venom",
   ["You are tempered against fire damage."] = "frost",
   ["You are tempered against elemental magic."] = "arcane",
@@ -78263,6 +78428,7 @@ end
 
 function snd.shapeshifter_bash()
   hp = 100*(gmcp.Char.Vitals.hp/gmcp.Char.Vitals.maxhp)
+  mad = tonumber(gmcp.Char.Vitals.madness)
 	
   if hp &lt;=40 and snd.shield_check() then
     if snd.punisher then
@@ -78272,6 +78438,9 @@ function snd.shapeshifter_bash()
 	else
     battack = "combo "..snd.bashing.target.." slash slash"
 	end
+  if mad &gt;= 69 then
+    battack = "eat corpse" .. snd.sep .. battack
+  end
 end
 
 function snd.infiltrator_bash()
@@ -80149,6 +80318,8 @@ function snd.load_def(option)
           if snd.balance.vitality then
             snd.defenses[h].needit = true
           end
+        elseif h == "def_divert_melee" and not hasSkill("ReflexiveDiversion") then
+          snd.defenses[h].needit = false
         else
           snd.defenses[h].needit = true
         end
@@ -80189,6 +80360,11 @@ def_speed = "on",
 def_dodge_melee = "on",
 def_nightsight = "on",
 def_clarity = "on",
+def_fangbarrier = "on",
+def_divert_melee = "on",
+--def_blindness = "on",
+--def_deafness = "on",
+def_irongrip = "on",
 },
 
 akkari = {
@@ -80200,7 +80376,8 @@ def_acuity = "on",
 def_stalking = "once",
 def_suppressed = "once",
 def_retaliation = "once",
-def_ascetic = "on"
+def_ascetic = "on",
+def_transcendence = "on",
 },
 
 
@@ -80342,7 +80519,7 @@ def_concentrate = "on",
 def_shadowblow = "on",
 def_blurred = "on",
 def_elusion = "on",
--- def_bloodrage = "on",
+def_bloodrage = "on",
 -- def_deathlink = "on",
 },
 
@@ -82436,7 +82613,7 @@ end</script>
     if (100 * (gmcp.Char.Vitals.mp / gmcp.Char.Vitals.maxmp)) &lt;= 40 then
       table.insert(snd.alerts, "\n&lt;brown&gt;       YOUR MANA IS LOW")
     end
-    if tonumber(gmcp.Char.Vitals.madness) &gt;= 60 then
+    if tonumber(gmcp.Char.Vitals.madness) &gt;= 69 then
       table.insert(snd.alerts, "\n&lt;red&gt;      THE MADNESS IS COMING, EAT UP")
     end
     if #snd.alerts &gt;= 1 then

--- a/BlunderGui.xml
+++ b/BlunderGui.xml
@@ -32,7 +32,7 @@
 				<colorTriggerBgColor>#000000</colorTriggerBgColor>
 				<regexCodeList />
 				<regexCodePropertyList />
-				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="yes" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="yes" isColorTriggerFg="no" isColorTriggerBg="no">
+				<Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="yes" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>Deathsight</name>
 					<script>if snd.gui.enabled then
   demonnic.chat:append("Misc")
@@ -76,8 +76,16 @@ end</script>
 						<string>The spicy, ashen smell that had been lingering begins to subside and you know the signal fire has been extinguished; there is five minutes before the event begins in the ruins.</string>
 						<string>A spicy, ashen smell touches your nose, the scent familiar to the incense used in the Ophidian Ruins, signalling an event within them has been signalled.</string>
 						<string>A spicy, ashen smell touches your nose, the scent familiar to the incense used in the Ophidian Ruins, signalling an event within them will begin within fifteen minutes.</string>
+						<string>A pulse of twin tremors washes over you from the leylines, the conjoined foci quivering as one of them is tapped.</string>
+						<string>A sudden rumbling seizes the continent of Sapience, shuddering briefly as the earth heaves against itself in a fitful tremor.</string>
+						<string>Inelegant patterns of green light dance across the horizon in a show of brilliance before quickly fading away.</string>
+						<string>A pulse of twin tremors washes over you from the leylines, the conjoined foci quivering as one of them is tapped.</string>
 					</regexCodeList>
 					<regexCodePropertyList>
+						<integer>3</integer>
+						<integer>3</integer>
+						<integer>3</integer>
+						<integer>3</integer>
 						<integer>3</integer>
 						<integer>3</integer>
 						<integer>3</integer>
@@ -234,6 +242,54 @@ end</script>
 					<colorTriggerBgColor>#000000</colorTriggerBgColor>
 					<regexCodeList>
 						<string>^(\w+) just thought\:</string>
+					</regexCodeList>
+					<regexCodePropertyList>
+						<integer>1</integer>
+					</regexCodePropertyList>
+				</Trigger>
+				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+					<name>Extra Deathsight Info</name>
+					<script>if snd.gui.enabled then
+  demonnic.chat:append("Misc")
+end</script>
+					<triggerType>0</triggerType>
+					<conditonLineDelta>0</conditonLineDelta>
+					<mStayOpen>0</mStayOpen>
+					<mCommand></mCommand>
+					<packageName></packageName>
+					<mFgColor>#ff0000</mFgColor>
+					<mBgColor>#ffff00</mBgColor>
+					<mSoundFile></mSoundFile>
+					<colorTriggerFgColor>#000000</colorTriggerFgColor>
+					<colorTriggerBgColor>#000000</colorTriggerBgColor>
+					<regexCodeList>
+						<string>^Your ally has fallen at .*$</string>
+						<string>^You divine the location of this death as .*$</string>
+						<string>^From your knowledge, that room is in .*$</string>
+					</regexCodeList>
+					<regexCodePropertyList>
+						<integer>1</integer>
+						<integer>1</integer>
+						<integer>1</integer>
+					</regexCodePropertyList>
+				</Trigger>
+				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+					<name>Wyrms</name>
+					<script>if snd.gui.enabled then
+  demonnic.chat:append("Misc")
+end</script>
+					<triggerType>0</triggerType>
+					<conditonLineDelta>0</conditonLineDelta>
+					<mStayOpen>0</mStayOpen>
+					<mCommand></mCommand>
+					<packageName></packageName>
+					<mFgColor>#ff0000</mFgColor>
+					<mBgColor>#ffff00</mBgColor>
+					<mSoundFile></mSoundFile>
+					<colorTriggerFgColor>#000000</colorTriggerFgColor>
+					<colorTriggerBgColor>#000000</colorTriggerBgColor>
+					<regexCodeList>
+						<string>^The Mhojave desert sands swirl in exultation, recognising .*'s feat in successfully dominating an earth wyrm weighing .* pounds!$</string>
 					</regexCodeList>
 					<regexCodePropertyList>
 						<integer>1</integer>
@@ -403,11 +459,12 @@ end</script>
    name = "vitals",
    x = 0, y = 0,
    width = "100%", height = "4%",
-   fgColor = "white",
+  color = "black", fgColor = "firebrick",
   }, leftContainer);
   vitals:setFontSize(11)
-end
-</script>
+  
+  vitals:cecho("&lt;center&gt;&lt;firebrick&gt;".."BLUNDER")
+end</script>
 					<eventHandlerList />
 				</Script>
 				<Script isActive="yes" isFolder="no">
@@ -418,7 +475,7 @@ end
    name = "wielding",
    x = 0, y = "4%",
    width = "100%", height = "3%",
-   color = "SteelBlue", fgColor = "white",
+   color = "black", fgColor = "firebrick",
    message = [[wielding]],
   }, leftContainer);
   wielding:setFontSize(9)
@@ -430,94 +487,24 @@ function updatedWielded()
     wielding:echo("&lt;center&gt;empty hands&lt;/center&gt;")
   else
     local string = ""
+    local hand = ""
+    if snd.wielded.right.name == "" and snd.weaponTwohanded(snd.wielded.left.name) then
+      hand = "Both Hands"
+    else
+      hand = "Left Hand"
+    end
     if snd.wielded.left.name ~= "" then
-      string = string .. "&lt;center&gt;" .. snd.weaponType(snd.wielded.left.name) .. "&lt;/center&gt;"
+      string = string .. "&lt;center&gt;&lt;SlateBlue&gt;"..hand..": &lt;firebrick&gt;" .. snd.weaponType(snd.wielded.left.name) .. "&lt;/center&gt;"
     end
     if snd.wielded.right.name ~= "" then
-      string = string .. "&lt;center&gt;" .. snd.weaponType(snd.wielded.right.name) .. "&lt;/center&gt;"
+      string = string .. "&lt;center&gt;&lt;SlateBlue&gt;Right Hand: &lt;firebrick&gt;" .. snd.weaponType(snd.wielded.right.name) .. "&lt;/center&gt;"
     end
-    wielding:echo(string)
+    wielding:cecho(string)
   end
 
 end
 registerAnonymousEventHandler("sunder_item_update","updatedWielded")</script>
 					<eventHandlerList />
-				</Script>
-				<Script isActive="yes" isFolder="no">
-					<name>time_update</name>
-					<packageName></packageName>
-					<script>  if snd.gui.enabled then
-  time = Geyser.Label:new({
-   name = "time",
-   x = 0, y = "7%",
-   width = "100%", height = "1.75%",
-   color = "black", fgColor = "white",
-   message = [[time]],
-  }, leftContainer);
-  time:setFontSize(7.45)
-end
-registerAnonymousEventHandler("sunder_login","time_update")
-function time_update()
-  if snd.gui.enabled then
-    sendGMCP("IRE.Time.Request")
-    
-    local d = gmcp.IRE.Time.List.day
-    local m = gmcp.IRE.Time.List.month
-    local y = gmcp.IRE.Time.List.year
-    
-    local t = gmcp.IRE.Time.List.time 
-    	if t:find("late night, approaching midnight") then
-    		time:setFontSize(8)
-     		t = "Late night"
-    	elseif t:find("It is deep night in Aetolia") then
-    		t = "Almost midnight"
-    		time:setFontSize(7.45)
-    	elseif t:find("It is deepest midnight.") then
-    		t = "Midnight"
-    		time:setFontSize(8)
-    	elseif t:find("It is the middle of the night in Aetolia") then
-    		t = "After midnight"
-    		time:setFontSize( 7.45)
-    	elseif t:find("early morning in Aetolia") then
-    		t = "Early morning"
-    		time:setFontSize(7.45)
-    	elseif t:find("approaching dawn.") then
-    		t = "Almost dawn"
-    		time:setFontSize(7.45)
-    	elseif t:find("It is dawn.") then
-    		t = "Dawn"
-    		time:setFontSize(8)
-    	elseif t:find("It's mid-") then
-    		t = "Mid-morning"
-    		time:setFontSize(8)
-    	elseif t:find("approaching noon") then
-    		t = "Almost noon"
-    		time:setFontSize(7.45)
-    	elseif t:find("exactly noon") then
-    		t = "Hiiiigh noooon"
-    		time:setFontSize(7.45)
-    	elseif t:find("early afternoon") then
-    		t = "Early afternoon"
-    		time:setFontSize(7.45)
-    	elseif t:find("It is late afternoon in Aetolia") then
-    		t = "Late afternoon"
-    		time:setFontSize(7.45)
-    	elseif t:find("dusk in Aet") then
-    		t = "Dusk"
-    		time:setFontSize(8)
-    	elseif t:find("Twilight has overtaken the light") then
-    		t = "Early evening"
-    		time:setFontSize(7.45)
-    	else 
-    		--This should only come about if they add a new time to the cycle.
-    	end
-    
-    time:echo("&lt;center&gt;"..t.." "..m.."/"..d.."/"..y.."&lt;/center&gt;")
-  end
-end</script>
-					<eventHandlerList>
-						<string>gmcp.IRE.Time.Update</string>
-					</eventHandlerList>
 				</Script>
 				<Script isActive="yes" isFolder="no">
 					<name>my status</name>
@@ -527,14 +514,14 @@ end</script>
    name = "mystatus",
    x = 0, y = "9%",
    width = "35%", height = "10.5%",
-   color = "slate_gray", fgColor = "white",
+   color = "dark_slate_gray", fgColor = "white",
    message = [[mystatus]],
   }, leftContainer);
   mystatus:setFontSize(9)
   	mystatus:setStyleSheet([[
   		border-width: 3px;
   		border-style: solid;
-  		border-color: DarkCyan;
+  		border-color: DarkRed;
   		
   	]])
   mystatus:echo("&lt;center&gt;".."PASN".."&lt;/center&gt;&lt;center&gt;prone&lt;/center&gt;")
@@ -556,7 +543,7 @@ end</script>
   	mylimbs:setStyleSheet([[
   		border-width: 3px;
   		border-style: solid;
-  		border-color: DarkCyan;
+  		border-color: DarkRed;
   		
   	]])
   mylimbs:echo("&lt;center&gt;0&lt;/center&gt;&lt;center&gt;/|\\&lt;/center&gt;&lt;center&gt;/\\&lt;/center&gt;")
@@ -578,7 +565,7 @@ end</script>
     myaffs:setStyleSheet([[
   border-width: 3px;
   border-style: solid;
-  border-color: DarkCyan;
+  border-color: DarkRed;
   ]])
 end</script>
 					<eventHandlerList />
@@ -661,11 +648,11 @@ end</script>
   }, leftContainer);
   toggles:setFontSize(9)
   toggles:clear()
-  toggles:cecho("\nattacking")
-  toggles:echo("\nbashing")
-  toggles:echo("\nfasthunt")
-  toggles:echo("\nquesting")
-  toggles:echo("\ndispersing")
+  toggles:cecho("\nAttacking")
+  toggles:echo("\nBashing")
+  toggles:echo("\nFasthunt")
+  toggles:echo("\nQuesting")
+  toggles:echo("\nDispersing")
 
   --toggles:echo("attacking\n&lt;center&gt;&lt;/center&gt;bashing\n&lt;center&gt;&lt;/center&gt;fasthunt")
 end</script>
@@ -684,10 +671,10 @@ end</script>
   }, leftContainer);
   toggles2:setFontSize(9)
   toggles2:clear()
-  toggles2:cecho("\naffcalling")
-  toggles2:echo("\ncalling")
-  toggles2:echo("\nlistening")
-  toggles2:echo("\nchameleon")
+  toggles2:cecho("\nAffcalling")
+  toggles2:echo("\nCalling")
+  toggles2:echo("\nListening")
+  toggles2:echo("\nChameleon")
   --toggles2:echo("affcalling\n&lt;center&gt;&lt;/center&gt;calling\n&lt;center&gt;&lt;/center&gt;listening")
 end</script>
 					<eventHandlerList />
@@ -708,9 +695,9 @@ end
 
 function colorMonolithLabel()
     if snd.monolith then
-      monolith:setColor("medium_sea_green")
+      monolith:setColor("SlateBlue")
     else
-      monolith:setColor("firebrick")
+      monolith:setColor("DarkRed")
     end
 end
 registerAnonymousEventHandler("sunder_item_update", "colorMonolithLabel")</script>
@@ -724,9 +711,10 @@ registerAnonymousEventHandler("sunder_item_update", "colorMonolithLabel")</scrip
    name = "exits",
    x = 0, y = "64%",
    width = "100%", height = "2%",
-   color = "midnight_blue", fgColor = "white",
+   color = "black", fgColor = "OrangeRed",
    message = [[exits]],
   }, leftContainer);
+  exits:setFontSize(11.00)
 end
 
 function snd.update_exits()
@@ -748,14 +736,14 @@ registerAnonymousEventHandler("sunder_room_updated", "snd.update_exits")</script
   enorian_people = Geyser.Label:new({
    name = "enorian_people",
    x = 0, y = "66.5%",
-   width = "51%", height = "17%",
+   width = "50%", height = "16.75%",
    color = "SlateGray", fgColor = "DeepSkyBlue",
    message = [[&lt;center&gt;Enorian&lt;\center&gt;]],
   }, leftContainer);
       enorian_people:setStyleSheet([[
   border-width: 3px;
   border-style: solid;
-  border-color: SlateGray;
+  border-color: DarkGoldenRod;
   ]])
 end</script>
 					<eventHandlerList />
@@ -766,15 +754,15 @@ end</script>
 					<script>if snd.gui.enabled then
   duiran_people = Geyser.Label:new({
    name = "duiran_people",
-   x = 0, y = "83%",
-   width = "51%", height = "17%",
+   x = 0, y = "83.27%",
+   width = "50%", height = "16.75%",
    color = "SlateGray", fgColor = "DeepSkyBlue",
    message = [[&lt;center&gt;Duiran&lt;\center&gt;]],
   }, leftContainer);
       duiran_people:setStyleSheet([[
   border-width: 3px;
   border-style: solid;
-  border-color: SlateGray;
+  border-color: green;
   ]])
 end</script>
 					<eventHandlerList />
@@ -785,15 +773,15 @@ end</script>
 					<script>if snd.gui.enabled then
   spines_people = Geyser.Label:new({
    name = "spines_people",
-   x = "-51%", y = "66.5%",
-   width = "51%", height = "17%",
+   x = "-50%", y = "66.5%",
+   width = "51%", height = "16.75%",
    color = "SlateGray", fgColor = "tomato",
    message = [[&lt;center&gt;Spines&lt;\center&gt;]],
   }, leftContainer);
         spines_people:setStyleSheet([[
   border-width: 3px;
   border-style: solid;
-  border-color: SlateGray;
+  border-color: MediumPurple;
   ]])
 end</script>
 					<eventHandlerList />
@@ -804,15 +792,15 @@ end</script>
 					<script>if snd.gui.enabled then
   bloodloch_people = Geyser.Label:new({
    name = "bloodloch_people",
-   x = "-51%", y = "83%",
-   width = "51%", height = "17%",
+   x = "-50%", y = "83.27%",
+   width = "51%", height = "16.75%",
    color = "SlateGray", fgColor = "tomato",
    message = [[&lt;center&gt;Bloodloch&lt;\center&gt;]],
   }, leftContainer);
         bloodloch_people:setStyleSheet([[
   border-width: 3px;
   border-style: solid;
-  border-color: SlateGray;
+  border-color: DarkRed;
   ]])
 end</script>
 					<eventHandlerList />
@@ -1171,6 +1159,67 @@ end
 registerAnonymousEventHandler("sunder_enemy_affs_updated", "display_enemy_affs")</script>
 					<eventHandlerList />
 				</Script>
+				<Script isActive="yes" isFolder="no">
+					<name>gui_time_update</name>
+					<packageName></packageName>
+					<script>  if snd.gui.enabled then
+    time = Geyser.Label:new({
+    name = "time",
+    x = 0, y = "7%",
+    width = "100%", height = "1.75%",
+    color = "black", fgColor = "white",
+    message = [[time]],
+    }, leftContainer);
+    time:setFontSize(7.45)
+  end
+
+function gui_time_update()
+  if snd.gui.enabled then
+
+    
+    	if snd.time.t == "Late night" then
+    		time:setFontSize(8)
+    	elseif snd.time.t == "Almost midnight" then
+    		time:setFontSize(7.45)
+    	elseif snd.time.t == "Midnight" then
+    		time:setFontSize(8)
+    	elseif snd.time.t == "After midnight" then
+    		time:setFontSize( 7.45)
+    	elseif snd.time.t == "Early morning" then
+    		time:setFontSize(7.45)
+    	elseif snd.time.t == "Almost dawn" then
+    		time:setFontSize(7.45)
+    	elseif snd.time.t == "Dawn" then
+    		time:setFontSize(8)
+    	elseif snd.time.t == "Mid-morning" then
+    		time:setFontSize(8)
+    	elseif snd.time.t == "Almost noon" then
+    		time:setFontSize(7.45)
+    	elseif snd.time.t == "Hiiiigh noooon" then
+    		time:setFontSize(7.45)
+    	elseif snd.time.t == "Early afternoon" then
+    		time:setFontSize(7.45)
+    	elseif snd.time.t == "Late afternoon" then
+    		time:setFontSize(7.45)
+    	elseif snd.time.t == "Dusk" then
+    		time:setFontSize(8)
+    	elseif snd.time.t == "Early evening" then
+    		time:setFontSize(7.45)
+    	else 
+    		--This should only come about if they add a new time to the cycle.
+    	end
+    
+    local timecolor = "&lt;orange&gt;"
+    if snd.time.night then
+      timecolor = "&lt;gray&gt;"
+    end
+    
+    
+    time:cecho("&lt;center&gt;"..timecolor..snd.time.t.." &lt;firebrick&gt;of &lt;dark_green&gt;"..string.format("%03d",snd.time.y).."&lt;magenta&gt;/&lt;dark_green&gt;"..string.format("%02d",snd.time.m).."&lt;magenta&gt;/&lt;dark_green&gt;"..string.format("%02d",snd.time.y).."&lt;/center&gt;")
+  end
+end</script>
+					<eventHandlerList />
+				</Script>
 			</ScriptGroup>
 			<ScriptGroup isActive="yes" isFolder="yes">
 				<name>Right</name>
@@ -1243,7 +1292,7 @@ see http://wiki.mudlet.org/w/Manual:Lua_Functions#getTime for information
 how to format the string
 ]]
 --demonnic.chat.config.timestamp = "HH:mm:ss"
-demonnic.chat.config.timestamp = false
+demonnic.chat.config.timestamp = "HH:mm:ss"
 
 --[[ Should we use our own colors for the timestamp?
 Set to true if you want to specify foreground and background colors
@@ -1251,7 +1300,7 @@ for the timestamp.
 Set to false if you want the timestamps background and foreground
 colors to match that of the mud output.
 ]]
-demonnic.chat.config.timestampCustomColor = false
+demonnic.chat.config.timestampCustomColor = true
 --[[
 and what foreground color? You can either use one of the 'named' colors
 (see http://wiki.mudlet.org/images/c/c3/ShowColors.png for available colors)
@@ -1265,10 +1314,10 @@ demonnic.chat.config.timestampFG = {
 }
 then the foreground for the timestamp would be 255 read, 100 green, and 0 blue
 ]]
-demonnic.chat.config.timestampFG = "red"
+demonnic.chat.config.timestampFG = "SlateBlue"
 
 --and background? Same rules as for the foreground above
-demonnic.chat.config.timestampBG = "blue"
+demonnic.chat.config.timestampBG = "black"
 
 --[[
 This is where you say what corner of the screen you want the tabbed chat on
@@ -1365,7 +1414,7 @@ Number of characters to wrap the chatlines at.
 This will also determine how wide the chat windows are.
 ]]
 
-demonnic.chat.config.width = 55
+demonnic.chat.config.width = 90
 
 --[[
 Set the color for the active tab. R,G,B format.
@@ -1413,7 +1462,7 @@ Set the color for the text on the inactive tabs. Uses color names.
 Defaulted this to white. So the tabs you're not looking at will be white text on boring grey background.
 ]]
 
-demonnic.chat.config.inactiveTabText = "white"
+demonnic.chat.config.inactiveTabText = "gray"
 
 --[[
 have to make sure a currentTab is set... 
@@ -1667,6 +1716,7 @@ function demonnic.chat:append(chat)
       colorLeader = string.format("&lt;%s,%s,%s:%s,%s,%s&gt;",ofr,ofg,ofb,obr,obg,obb)
     end
     local fullstamp = string.format("%s%s",colorLeader,timestamp)
+    
       demonnic.chat.windows[chat]:decho(fullstamp)
       demonnic.chat.windows[chat]:echo(" ")
       if demonnic.chat.config.Alltab then 
@@ -1743,6 +1793,39 @@ function demonnic.chat:bottomleft()
     width=string.format("%sc",demonnic.chat.config.width),
     height=string.format("%ic", demonnic.chat.config.lines + 2),
   }
+end
+
+function sendTimestamp(chat)
+  -- Handle timestamps
+  if snd.toggles.chattime and demonnic.chat.config.timestamp then
+    local timestamp = getTime(true, demonnic.chat.config.timestamp)
+    local tsfg = {}
+    local tsbg = {}
+    local colorLeader = ""
+    if demonnic.chat.config.timestampCustomColor then
+      if type(demonnic.chat.config.timestampFG) == "string" then
+        tsfg = color_table[demonnic.chat.config.timestampFG]
+      else
+        tsfg = demonnic.chat.config.timestampFG
+      end
+      if type(demonnic.chat.config.timestampBG) == "string" then
+        tsbg = color_table[demonnic.chat.config.timestampBG]
+      else
+        tsbg = demonnic.chat.config.timestampBG
+      end
+      colorLeader = string.format("&lt;%s,%s,%s:%s,%s,%s&gt;",tsfg[1],tsfg[2],tsfg[3],tsbg[1],tsbg[2],tsbg[3])
+    else
+      colorLeader = string.format("&lt;%s,%s,%s:%s,%s,%s&gt;",ofr,ofg,ofb,obr,obg,obb)
+    end
+    local fullstamp = string.format("%s%s",colorLeader,timestamp)
+    
+      demonnic.chat.windows[chat]:decho(fullstamp)
+      demonnic.chat.windows[chat]:echo(" ")
+      if demonnic.chat.config.Alltab then 
+        demonnic.chat.windows[demonnic.chat.config.Alltab]:decho(fullstamp)
+        demonnic.chat.windows[demonnic.chat.config.Alltab]:echo(" ")
+      end
+  end
 end</script>
 							<eventHandlerList />
 						</Script>
@@ -1880,17 +1963,17 @@ registerAnonymousEventHandler("sunder_update_vitals", "snd.set_vitals")</script>
     if snd.toggles[tgs[tog]] then
       if tgs[tog] == "dispersing" then
         if snd.disperse == "callers" then
-    			toggles:cecho("\n&lt;yellow&gt;dispersing")
+    			toggles:cecho("\n&lt;yellow&gt;Dispersing")
     		elseif snd.disperse == "all" then
-    			toggles:cecho("\n&lt;green&gt;dispersing")
+    			toggles:cecho("\n&lt;green&gt;Dispersing")
         else
-          toggles:cecho("\n&lt;red&gt;dispersing")
+          toggles:cecho("\n&lt;red&gt;Dispersing")
         end
       else
-        toggles:cecho("\n&lt;green&gt;" .. tgs[tog])
+        toggles:cecho("\n&lt;green&gt;" .. tgs[tog]:gsub("^%l", string.upper))
       end
     else
-      toggles:cecho("\n&lt;red&gt;" .. tgs[tog])
+      toggles:cecho("\n&lt;red&gt;" .. tgs[tog]:gsub("^%l", string.upper))
     end
   end
   
@@ -1898,9 +1981,9 @@ registerAnonymousEventHandler("sunder_update_vitals", "snd.set_vitals")</script>
   
   for tog in pairs(tgs) do
     if snd.toggles[tgs[tog]] then
-      toggles2:cecho("\n&lt;green&gt;" .. tgs[tog])
+      toggles2:cecho("\n&lt;green&gt;" .. tgs[tog]:gsub("^%l", string.upper))
     else
-      toggles2:cecho("\n&lt;red&gt;" .. tgs[tog])
+      toggles2:cecho("\n&lt;red&gt;" .. tgs[tog]:gsub("^%l", string.upper))
     end
   end
 end
@@ -1939,7 +2022,7 @@ registerAnonymousEventHandler("sunder_update_toggles", "snd.updateToggles")</scr
     
 
   if snd.gui.enabled then
-    local colors = {["Enorian"] = npb.t.config.colors["enorian"], ["Duiran"] = npb.t.config.colors["duiran"], ["Spinesreach"] = npb.t.config.colors["spinesreach"], ["Bloodloch"] = npb.t.config.colors["bloodloch"]}
+    local colors = {["Enorian"] = npb.t.config.colors["enorian"] or "gold", ["Duiran"] = npb.t.config.colors["duiran"] or "lawn_green", ["Spinesreach"] = npb.t.config.colors["spinesreach"] or "medium_purple", ["Bloodloch"] = npb.t.config.colors["bloodloch"] or "firebrick"}
     -- if sndNDB ~= nil then
     --  colors = sndNDB.highlighting
     -- end
@@ -1969,6 +2052,7 @@ snd.channel_list =
   {
     ["newbie"] = "Misc",
     ["market"] = "Misc",
+    ["alerts"] = "Misc",
     ["web"] = "Web",
     ["ct"] = "City",
     ["cnt"] = "City",
@@ -2076,7 +2160,6 @@ function gmcp_communication()
   
   if snd.channel_ignores[channel] then return false end
 
-  
   --NDB highlighting of text
   if sndNDB.highlightNames then
     local format = string.match(text, "&lt;%d+.-&gt;")
@@ -2098,9 +2181,77 @@ function gmcp_communication()
     end
   end
   
+   -- Handle timestamps
+  sendTimestamp(snd.last_channel)
+  
   demonnic.chat:decho(snd.last_channel, text.."\n")
   -- enableTrigger("generic capture")
-end</script>
+end
+
+function gcmp_deaths()
+ 
+  local text = gmcp.Deathsight.message
+  local assists = gmcp.Deathsight.assists
+  local rawtext = ansi2string(text)
+  --text = ansi2decho(text)
+  text = text:gsub(string.char(27) .. [[.-]] .. string.char(4), "")
+ 
+  local linecolor = "&lt;100,100,150&gt;"
+  --NDB highlighting of text
+  if sndNDB.highlightNames then
+    local alreadyHighlighted = {}
+    for word in string.gmatch(text, "%a+") do
+      if sndNDB_Exists(word) and not table.contains(alreadyHighlighted, word) then
+        local color = sndNDB_getColour(word) or "white"
+        color =
+          "&lt;" ..
+          color_table[color][1] ..
+          "," ..
+          color_table[color][2] ..
+          "," ..
+          color_table[color][3] ..
+          "&gt;"
+        text = linecolor .. text:gsub(word, color .. word .. linecolor)
+        table.insert(alreadyHighlighted, word)
+      end
+    end
+  end
+  
+  -- Handle timestamps
+  sendTimestamp("Misc")
+  demonnic.chat:decho("Misc", text.."\n")
+  
+  if assists~="" then
+    local people = string.match(assists, "They were assisted by: (.+)%.\n"):split(", ")
+    local text = linecolor .. "They were assisted by: "
+    for i, person in ipairs(people) do
+      if sndNDB.highlightNames and sndNDB_Exists(person) then
+        local color = sndNDB_getColour(person) or "white"
+        color =
+          "&lt;" ..
+          color_table[color][1] ..
+          "," ..
+          color_table[color][2] ..
+          "," ..
+          color_table[color][3] ..
+          "&gt;"
+        if i &gt; 1 then
+          text = text .. linecolor .. ", " .. color .. person
+        else
+          text = text .. color .. person
+        end
+      else
+         if i &gt; 1 then
+          text = text .. linecolor .. ", " .. person
+        else
+          text = text .. person
+        end
+      end
+    end
+    demonnic.chat:decho("Misc", text.."\n")
+  end
+end
+registerAnonymousEventHandler("gmcp.Deathsight", "gcmp_deaths")</script>
 					<eventHandlerList>
 						<string>gmcp.Comm.Channel.Start</string>
 					</eventHandlerList>

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Log off. Open your Aetolia profile in Offline mode and:
 
 ### CAVEAT
 Do to the way updates are handled (this is a Mudlet thing). Any custom
-aliases/triggers/etc that you make, you should ALWAYS put OUTSIDE the Sunder
-package even if they depend/use features from Sunder.
+aliases/triggers/etc that you make, you should ALWAYS put OUTSIDE the Blunder
+package even if they depend/use features from Blunder.
 What I do is I make a "Personal" folder and save my custom stuff under there.
 If you don't follow this advice, when you remove the package to update, you
 will lose you custom stuff.


### PR DESCRIPTION

New features and changes:

Blunder:
-Troop blockade bypassing now works for all destinations and also if you start pathing from a room adjucent to a block.
-Prism defense is now "toggle prismdef" (will change every toggle to follow this standard)
-Support for Stability artifact "toggle stability"
-Deathsight and Thirdeye will now check if you have the skills and use those instead of popping pills.
-Fang barrier, irongrip and divert melee added to default defenses. They will apply only if available and divert melee only if you also have ReflexiveDiversion.
-Blood rage added to default defenses. Will only apply if Praenomen is on Phrenesis path. Same for Akkari mirror.
-Proper time tracking (can do things based on time of Aetolian day now -- time_update event handler).
-Praenomen Stalking will now activate during night on its own.
-Chats timestamp support. "toggle chattime". Standardized implementation for GUIs (Kai version not updated for this yet).
-Toggle and defense keep up output now shows [Blunder] instead of [SND].

BlunderGui:
-Add more foci lines to the chat tab.
-Proper GMCP deathsight implementation with extra triggers for the additional information and highlight supported.
-Proper weapon detection of two handed weapons.
-Decouple time of day tracking from GUI.
-Chat timestamp implementation for GMCP chats, helper function.
-Full facelift and BL theming.

Fixed defects from Sunder:
Blunder:
-Some quests now only trigger on the appropriate areas (will fix them all so they don't spam)
-Bash room function "aa" will now properly update GUI when you move to another room instead of still showing bashing on.
-Minor fixes on GUI updates that should happen but didn't.
-Shapeshifter bashing script now eats corpse when 69 or over madness.

BlunderGui:
-Chat timestamps were only working for chat text captured from triggers and required manual edit of config to enable.